### PR TITLE
Fix course edit

### DIFF
--- a/src/Resources/contao/templates/wb_sms_course_add.html5
+++ b/src/Resources/contao/templates/wb_sms_course_add.html5
@@ -98,6 +98,7 @@
         <?php elseif (is_numeric($this->user_course['coLeader'])): ?>
                 <div class="cell">
                     <?= $this->user_course['coLeader'] != '0' ? WBGym\WBGym::student($this->user_course['coLeader']) : '--' ?>
+                    <input type="hidden" name="second_leader" value="<?= $this->user_course['coLeader'] ?>" />
                 </div>
             </div>
         <?php endif; ?>


### PR DESCRIPTION
Wenn man versucht, einen bereits existierenden Kurs zu aktualisieren, wird dies fehlschlagen, da kein zweiter Kursleiter an den Server gesendet wird. 

# Lösung
Versteckte Eingabe des 2. Kursleiters, die automatisch ausgefüllt ist. 
Wenn man versucht, ihn zu verändern, wird es nicht gespeichert. 